### PR TITLE
Adding fail date functionality 

### DIFF
--- a/bin/sca-task.js
+++ b/bin/sca-task.js
@@ -409,6 +409,7 @@ function handle_requested(task, next) {
         logger.debug("dependency failed.. failing this task");
         task.status_msg = "Dependency failed.";
         task.status = "failed";
+	task.fail_date = new Date();
         task.save(function(err) {
             if(err) return next(err);
             update_instance_status(task.instance_id, next);
@@ -467,6 +468,7 @@ function handle_requested(task, next) {
                     logger.error(err);
                     task.status = "failed";
                     task.status_msg = err;
+		    task.fail_date = new Date();
                     task.save(function(err) {
                         if(err) logger.error(err);
                         update_instance_status(task.instance_id, err=>{
@@ -582,6 +584,7 @@ function handle_running(task, next) {
         if(!resource) {
             task.status = "failed";
             task.status_msg = "Lost resource "+task.resource_id;
+	    task.fail_date = new Date();
             task.save(function(err) {
                 if(err) return next(err);
                 update_instance_status(task.instance_id, next);
@@ -625,6 +628,7 @@ function handle_running(task, next) {
                                 common.progress(task.progress_key, {status: 'failed', msg: err.toString()});
                                 task.status = "failed";
                                 task.status_msg = err;
+				task.fail_date = new Date();
                                 task.save(function(err) {
                                     if(err) return next(err);
                                     update_instance_status(task.instance_id, next);
@@ -665,6 +669,7 @@ function handle_running(task, next) {
                             common.progress(task.progress_key, {status: 'failed', msg: 'Service failed'});
                             task.status = "failed";
                             task.status_msg = out;
+			    task.fail_date = new Date();
                             task.save(function(err) {
                                 if(err) return next(err);
                                 update_instance_status(task.instance_id, next);

--- a/bin/sca-task.js
+++ b/bin/sca-task.js
@@ -409,7 +409,7 @@ function handle_requested(task, next) {
         logger.debug("dependency failed.. failing this task");
         task.status_msg = "Dependency failed.";
         task.status = "failed";
-	task.fail_date = new Date();
+        task.fail_date = new Date();
         task.save(function(err) {
             if(err) return next(err);
             update_instance_status(task.instance_id, next);
@@ -468,7 +468,7 @@ function handle_requested(task, next) {
                     logger.error(err);
                     task.status = "failed";
                     task.status_msg = err;
-		    task.fail_date = new Date();
+                    task.fail_date = new Date();
                     task.save(function(err) {
                         if(err) logger.error(err);
                         update_instance_status(task.instance_id, err=>{
@@ -584,7 +584,7 @@ function handle_running(task, next) {
         if(!resource) {
             task.status = "failed";
             task.status_msg = "Lost resource "+task.resource_id;
-	    task.fail_date = new Date();
+            task.fail_date = new Date();
             task.save(function(err) {
                 if(err) return next(err);
                 update_instance_status(task.instance_id, next);
@@ -628,7 +628,7 @@ function handle_running(task, next) {
                                 common.progress(task.progress_key, {status: 'failed', msg: err.toString()});
                                 task.status = "failed";
                                 task.status_msg = err;
-				task.fail_date = new Date();
+                                task.fail_date = new Date();
                                 task.save(function(err) {
                                     if(err) return next(err);
                                     update_instance_status(task.instance_id, next);
@@ -669,7 +669,7 @@ function handle_running(task, next) {
                             common.progress(task.progress_key, {status: 'failed', msg: 'Service failed'});
                             task.status = "failed";
                             task.status_msg = out;
-			    task.fail_date = new Date();
+                            task.fail_date = new Date();
                             task.save(function(err) {
                                 if(err) return next(err);
                                 update_instance_status(task.instance_id, next);


### PR DESCRIPTION
Requesting to add "fail date" functionality. This simple addition will make things much easier for DAART to accurately display the tasks that have failed... even after the task status has been set to removed. This will also help DAART administrator monitoring a "success rate" of tasks (this is information that I am not able to retrieve at the moment). Let me know if my implementation is not accurate or complete. 
